### PR TITLE
handle JSON.parse exception in makeRequest

### DIFF
--- a/addon/authenticators/oauth2-password-grant.js
+++ b/addon/authenticators/oauth2-password-grant.js
@@ -325,7 +325,13 @@ export default BaseAuthenticator.extend({
     return new RSVP.Promise((resolve, reject) => {
       fetch(url, options).then((response) => {
         response.text().then((text) => {
-          let json = text ? JSON.parse(text) : {};
+          var json;
+          try {
+            json = JSON.parse(text);
+          } catch (e) {
+            json = {};
+          }
+
           if (!response.ok) {
             response.responseJSON = json;
             reject(response);


### PR DESCRIPTION
makeRequest is failing when response is not JSON string. For example if a server returns 401 with empty body or some text.